### PR TITLE
feat: mostrar OE en detalle de despacho

### DIFF
--- a/src/app/modules/despacho/componentes/despacho-detalle/despacho-detalle.component.html
+++ b/src/app/modules/despacho/componentes/despacho-detalle/despacho-detalle.component.html
@@ -115,8 +115,12 @@
               </td>
               <td
                 class="px-4 py-3 font-bold text-gray-700 border-r border-gray-300 bg-gray-100"
-              ></td>
-              <td class="px-4 py-3 border-r border-gray-300"></td>
+              >
+                OE
+              </td>
+              <td class="px-4 py-3 border-r border-gray-300">
+                {{ despacho().entrega_id }}
+              </td>
             </tr>
             <tr class="border-b border-gray-300">
               <td


### PR DESCRIPTION
## Summary
- Muestra el campo OE (entrega_id) en la tabla de detalle del despacho, en la fila de Visitas al lado derecho
- El campo ya existía en la interfaz y venía del API, solo faltaba mostrarlo en el HTML

## Test plan
- [ ] Abrir un despacho con OE asignada y verificar que se muestra el valor
- [ ] Abrir un despacho sin OE y verificar que muestra 0